### PR TITLE
[Code Refactoring] Seprate out getCommonEditTextFieldProps method into new file as a part of code Refactoring 

### DIFF
--- a/frontend/src/components/ownerDetails/OwnerDetailsLoggedInView.tsx
+++ b/frontend/src/components/ownerDetails/OwnerDetailsLoggedInView.tsx
@@ -11,6 +11,8 @@ import { CreateNewRowStrategy } from "./commonElement/Strategy/CreateNewRowStrat
 import { SaveRowEditsStrategy } from './commonElement/Strategy/SaveRowEditsStrategy';
 import { DeleteRowStrategy } from './commonElement/Strategy/DeleteRowStrategy';
 
+import  getEditTextFieldProps  from './commonElement/GetEditTextFieldProps'; // Adjust the path to your GetEditTextFieldProps file
+
 //Factory DesignPattern Used for the Main Grid View
 import { GridFactory } from './commonElement/Factory/GridFactory'; // Adjust the path to your GridFactory file
 //-------------------------------End of Imports Section---------------------
@@ -75,74 +77,7 @@ const OwnerDetailsLoggedInView = () => {
   );
 
   //This function is called when the user clicks on the EDIT button to set the Edit Modal Properties of The Columns.
-  const getCommonEditTextFieldProps = commonImports.useCallback(
-    (
-      cell: commonImports.MRT_Cell<OwnerDetailsModel.IOwnerDetailsViewModel>
-    ): commonImports.MRT_ColumnDef<OwnerDetailsModel.IOwnerDetailsViewModel>["muiTableBodyCellEditTextFieldProps"] => {
-      if (cell.column.id === "userId") {
-        return {
-          select: true,
-          label: "User Name",
-          children: usersArr.map((option) => (
-            <commonImports.MenuItem key={option._id} value={option._id}>
-              {option.username}-{option.role}
-            </commonImports.MenuItem>
-          )),
-          error: !!validationErrors[cell.id],
-          helperText: validationErrors[cell.id],
-          onChange: (e) => {
-            const value = e.target.value;
-            if (!value) {
-              setValidationErrors((prev) => ({
-                ...prev,
-                [cell.id]: "Required",
-              }));
-            } else {
-              setValidationErrors((prev) => {
-                const next = { ...prev };
-                delete next[cell.id];
-                return next;
-              });
-            }
-            //cell.setEditingCellValue(value);
-          },
-        };
-      } else if (cell.column.id === "_id") {
-        return {
-          style: { display: "none" },
-        };
-      } else if (
-        cell.column.id === "createdAt" ||
-        cell.column.id === "updatedAt"
-      ) {
-        return {
-          style: { display: "none" },
-        };
-      } else {
-        return {
-          error: !!validationErrors[cell.id],
-          helperText: validationErrors[cell.id],
-          onChange: (e) => {
-            const value = e.target.value;
-            if (!value) {
-              setValidationErrors((prev) => ({
-                ...prev,
-                [cell.id]: "Required",
-              }));
-            } else {
-              setValidationErrors((prev) => {
-                const next = { ...prev };
-                delete next[cell.id];
-                return next;
-              });
-            }
-            //cell.setEditingCellValue(value);
-          },
-        };
-      }
-    },
-    [validationErrors]
-  );
+  // const getCommonEditTextFieldProps = getEditTextFieldProps(setValidationErrors, usersArr); 
 
   //-----------------All the Function Declarations Ends Here-----------------
 
@@ -159,7 +94,7 @@ const OwnerDetailsLoggedInView = () => {
   }, []);
 
   //This is Used to set the columns of the table
-  const ownerDetailsGridColumns = GridFactory(getCommonEditTextFieldProps, usersArr);
+  const ownerDetailsGridColumns = GridFactory(getEditTextFieldProps, usersArr,validationErrors,setValidationErrors);
 
   const handleOk = () => {
     // Perform the operation you want when the OK button is clicked

--- a/frontend/src/components/ownerDetails/commonElement/Factory/GridFactory.tsx
+++ b/frontend/src/components/ownerDetails/commonElement/Factory/GridFactory.tsx
@@ -1,6 +1,6 @@
 // GridFactory.tsx
 import * as commonImports from "../../../../commonCode/importMRTRelated";
-import React from 'react';
+import React from "react";
 import * as OwnerDetailsModel from "../../../../models/ownerDetails";
 
 type FieldConfig = {
@@ -10,7 +10,12 @@ type FieldConfig = {
   renderCell?: (cell: any) => JSX.Element;
 };
 
-export const GridFactory = (getCommonEditTextFieldProps: any, usersArr: any[]) => {
+export const GridFactory = (
+  getCommonEditTextFieldProps: any,
+  usersArr: any[],
+  validationErrors: any,
+  setValidationErrors: any
+) => {
   const ownerDetailsGridColumns = commonImports.useMemo<
     commonImports.MRT_ColumnDef<OwnerDetailsModel.IOwnerDetailsViewModel>[]
   >(
@@ -24,7 +29,12 @@ export const GridFactory = (getCommonEditTextFieldProps: any, usersArr: any[]) =
         enableEditing: false, //disable editing on this column
         editable: "never",
         muiTableBodyCellEditTextFieldProps: ({ cell }) => ({
-          ...getCommonEditTextFieldProps(cell),
+          ...getCommonEditTextFieldProps(
+            cell,
+            validationErrors,
+            setValidationErrors,
+            usersArr
+          ),
         }),
       },
       {
@@ -99,4 +109,4 @@ export const GridFactory = (getCommonEditTextFieldProps: any, usersArr: any[]) =
     [getCommonEditTextFieldProps, usersArr]
   );
   return ownerDetailsGridColumns;
-}
+};

--- a/frontend/src/components/ownerDetails/commonElement/GetEditTextFieldProps.ts
+++ b/frontend/src/components/ownerDetails/commonElement/GetEditTextFieldProps.ts
@@ -1,0 +1,53 @@
+import * as commonImports from "./../../../commonCode/importMRTRelated";
+import * as OwnerDetailsModel from "../../../models/ownerDetails";
+import * as UserModel from "../../../models/user";
+
+const getEditTextFieldProps = (
+    cell: commonImports.MRT_Cell<OwnerDetailsModel.IOwnerDetailsViewModel>,
+  validationErrors: { [key: string]: string},
+  setValidationErrors: React.Dispatch<React.SetStateAction<{ [key: string]: string}>>,
+  options: UserModel.User[]
+) =>{
+    commonImports.useCallback(
+        (
+            cell: commonImports.MRT_Cell<OwnerDetailsModel.IOwnerDetailsViewModel>,
+            validationErrors: { [key: string]: string},
+          options: UserModel.User[]
+        ): commonImports.MRT_ColumnDef<OwnerDetailsModel.IOwnerDetailsViewModel>["muiTableBodyCellEditTextFieldProps"] => {
+          if (cell.column.id === "userId") {
+            return {
+              select: true,
+              label: "User Name",
+              children: options.map(
+                (option: UserModel.User) =>
+                  `
+                       <commonImports.MenuItem key={option._id} value={option._id}>
+                        {option.username}-{option.role}
+                        </commonImports.MenuItem>
+                       `
+              ),
+              error: !!validationErrors[cell.id],
+              helperText: validationErrors[cell.id],
+              onChange: (e) => {
+                const value = e.target.value;
+                if (!value) {
+                  setValidationErrors((prev) => ({
+                    ...prev,
+                    [cell.id]: "Required",
+                  }));
+                } else {
+                  setValidationErrors((prev) => {
+                    const next = { ...prev };
+                    delete next[cell.id];
+                    return next;
+                  });
+                }
+                //cell.setEditingCellValue(value);
+              },
+            };
+          }
+        },
+        []
+        );
+}
+export default getEditTextFieldProps;


### PR DESCRIPTION
[Code Refactoring] Seprate out getCommonEditTextFieldProps method into new file as a part of code Refactoring 

#5 [Code Refactoring] Seprate out getCommonEditTextFieldProps method into new file as a part of code Refactoring 

